### PR TITLE
Fix duplicates in topic creation

### DIFF
--- a/DAL/Models/NewDataEntry.cs
+++ b/DAL/Models/NewDataEntry.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
 
 namespace DAL.Models
 {
+    [Index(nameof(SourceRecordId), IsUnique = true)]
     public class NewDataEntry
     {
+        [Key]
         public int Id { get; set; }
         public string ParserName { get; set; } = null!;
         public string SourceRecordId { get; set; } = null!;

--- a/Ozon.Parsers/Runners/ChatsParserRunner.cs
+++ b/Ozon.Parsers/Runners/ChatsParserRunner.cs
@@ -36,6 +36,10 @@ namespace Ozon.Parsers.Runners
 
                 foreach (var chatId in data)
                 {
+                    var existing = newDataRepository.GetEntryBySourceRecordId(chatId);
+                    if (existing != null)
+                        continue;
+
                     var newEntry = new NewDataEntry
                     {
                         ParserName = "ChatParserApp",


### PR DESCRIPTION
## Summary
- ensure unique entries for new data records
- avoid adding duplicate chat IDs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce2df79cc832d88bb994d6f442606